### PR TITLE
 Commits on Apr 30, 2024      Patch the isConfigSupported function so it works with unreal projects 

### DIFF
--- a/src/main/kotlin/com/github/rebel000/cmdlineargs/ArgumentsService.kt
+++ b/src/main/kotlin/com/github/rebel000/cmdlineargs/ArgumentsService.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.jetbrains.rider.cpp.run.configurations.CppProjectConfiguration
 import com.jetbrains.rider.cpp.run.configurations.launch.LocalCppProjectLaunchParameters
+import com.jetbrains.rider.cpp.run.configurations.rdjson.RdJsonLaunchParameters
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.projectView.solutionDirectory
 import com.jetbrains.rider.projectView.solutionName

--- a/src/main/kotlin/com/github/rebel000/cmdlineargs/ArgumentsService.kt
+++ b/src/main/kotlin/com/github/rebel000/cmdlineargs/ArgumentsService.kt
@@ -161,6 +161,9 @@ class ArgumentsService(private val project: Project) : Disposable {
                 if (launchParameters is LocalCppProjectLaunchParameters) {
                     return true
                 }
+                else if (launchParameters is RdJsonLaunchParameters) {
+                    return true
+                }
             }
         }
         else if (cfg is UwpConfiguration


### PR DESCRIPTION
I've noticed that the plugin shows as not supporting the .uproject, but I see no particular reason why it shouldn't since those automated projects supports extra custom arguments. With this change the plugin seems to go through and send the proper arguments to the exe on launch and debug. I've mainly tested on a .uproject file and checked the output of the CppConfigurationParametersExtension to be correct.

Let me know if there's any other test you'd like me to perform.