### PR TITLE
Bumping editor support to 2025.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 .qodana
 build
+
+.intellijPlatform/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
-        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"), useInstaller = false)
 
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })
@@ -43,7 +43,6 @@ dependencies {
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
-        instrumentationTools()
         pluginVerifier()
         zipSigner()
         testFramework(TestFrameworkType.Platform)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@ pluginGroup = com.github.rebel000.cmdlineargs
 pluginName = CommandlineArgumentsWCheckboxes
 # pluginRepositoryUrl = https://github.com/rebel-000/CommandlineArgumentsWCheckboxes
 # SemVer format -> https://semver.org
-pluginVersion = 2.1.2
+pluginVersion = 2.1.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
-pluginUntilBuild = 243.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = RD
-platformVersion = 2024.3
-#platformVersion = 2024.1-SNAPSHOT
+platformVersion = 2025.1
+#platformVersion = 2025.1-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ junit = "4.13.2"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.0.1"
-kotlin = "1.9.25"
-kover = "0.8.3"
+intelliJPlatform = "2.5.0"
+kotlin = "2.1.20"
+kover = "0.9.1"
 qodana = "2024.2.3"
 
 [libraries]


### PR DESCRIPTION
I got 2025.1 on Rider this morning, and the plugin was limited to 243, so I bumped it to 251.

I didn't do thorough testing, but building the plugin and installing it on my local editor (#RD-251.23774.437) works fine.
I also followed some warnings, adding .intellijPlatform/ to gitignore, setting useInstaller to false on the platform, removing instrumentationTools().